### PR TITLE
Saving assignment id instead of objects in the department object

### DIFF
--- a/admin/script.js
+++ b/admin/script.js
@@ -124,7 +124,7 @@ function assignReport(reportId,departmentId){
                     //Push the new assignment
                     //**Some redundant work happening here(Assignment is saved twice, will discuss and fix)
                     assignments.push(assignment);
-                    departments[j].assignments.push(assignment);
+                    departments[j].assignments.push(assignment.id);
                     
                     //save to local storage
                     localStorage.setItem('departments',JSON.stringify(departments));


### PR DESCRIPTION
We no longer saving the assignment object twice
Now we save the assignment as a separate entity
Then save the assignment ID to the department entity